### PR TITLE
feat: implement retry/DLQ (spec v1.1.0)

### DIFF
--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,5 +1,5 @@
 spec_version: "1.1.0"
-implementation_version: "1.1.0"
+implementation_version: "1.2.0"
 language: ruby
 package: "event_people (RubyGems)"
 status: stable
@@ -19,9 +19,6 @@ implemented:
   - RabbitContext
   - Topic
   - Queue
-
-# Spec components not yet implemented (pending in spec too)
-pending:
   - RetryManager
   - "Event.retryCount"
   - "Event.incrementRetryCount"
@@ -35,6 +32,9 @@ pending:
   - "RabbitContext.maxRetries"
   - "RabbitContext.isLastRetry"
   - "RabbitContext.dlqName"
+
+# Spec components not yet implemented (pending in spec too)
+pending: []
 
 # Structural or naming departures from the spec
 # (Ruby module-qualified class names are an accepted adaptation, not a deviation)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    event_people (1.0.7)
+    event_people (1.2.0)
       bunny (~> 2.7)
 
 GEM

--- a/lib/event_people.rb
+++ b/lib/event_people.rb
@@ -11,6 +11,7 @@ require 'event_people/broker/context'
 require 'event_people/broker/rabbit'
 require 'event_people/broker/rabbit/queue'
 require 'event_people/broker/rabbit/rabbit_context'
+require 'event_people/broker/rabbit/retry_manager'
 require 'event_people/broker/rabbit/topic'
 
 module EventPeople

--- a/lib/event_people/broker/base.rb
+++ b/lib/event_people/broker/base.rb
@@ -15,13 +15,13 @@ module EventPeople
         raise NotImplementedError.new('Must be implemented')
       end
 
-      def self.consume(event_name, &block)
+      def self.consume(event_name, retry_config: {}, &block)
         consumers[event_name] ||= begin
-          new.consume(event_name, &block)
+          new.consume(event_name, retry_config: retry_config, &block)
         end
       end
 
-      def consume(event_name, &block)
+      def consume(event_name, retry_config: {}, &block)
         raise NotImplementedError.new('Must be implemented')
       end
 

--- a/lib/event_people/broker/context.rb
+++ b/lib/event_people/broker/context.rb
@@ -13,6 +13,14 @@ module EventPeople
         raise NotImplementedError.new('Must be implemented')
       end
 
+      def max_retries
+        raise NotImplementedError.new('Must be implemented')
+      end
+
+      def is_last_retry
+        raise NotImplementedError.new('Must be implemented')
+      end
+
       def success!
         warn '[DEPRECATED] EventPeople: `success!` is deprecated, use `success` instead. Will be removed in a future version.'
         success

--- a/lib/event_people/broker/rabbit.rb
+++ b/lib/event_people/broker/rabbit.rb
@@ -5,8 +5,8 @@ module EventPeople
         @@connection ||= session
       end
 
-      def consume(event_name, &block)
-        Queue.subscribe(channel, event_name, &block)
+      def consume(event_name, retry_config: {}, &block)
+        Queue.subscribe(channel, event_name, retry_config: retry_config, &block)
       end
 
       def produce(events)

--- a/lib/event_people/broker/rabbit/queue.rb
+++ b/lib/event_people/broker/rabbit/queue.rb
@@ -6,18 +6,21 @@ module EventPeople
         @channel.prefetch(1)
       end
 
-      def self.subscribe(channel, routing_key, &block)
-        new(channel).subscribe(routing_key, &block)
+      def self.subscribe(channel, routing_key, retry_config: {}, &block)
+        new(channel).subscribe(routing_key, retry_config: retry_config, &block)
       end
 
-      def subscribe(routing_key, &block)
+      def subscribe(routing_key, retry_config: {}, &block)
         base_name = routing_key.split('.')[0..2].join('.')
         name = queue_name("#{base_name}.all")
 
-        channel.queue(name, queue_options)
+        declare_dlx_and_dlq
+        declare_retry_queue(name)
+
+        channel.queue(name, main_queue_options)
                .bind(topic, routing_key: routing_key)
                .subscribe(manual_ack: true) do |delivery_info, properties, payload|
-                 callback(delivery_info, properties, payload, &block)
+                 callback(delivery_info, properties, payload, name, retry_config, &block)
                end
       end
 
@@ -25,11 +28,37 @@ module EventPeople
 
       attr_reader :channel
 
-      def callback(delivery_info, properties, payload, &block)
-        event_name = delivery_info.routing_key
+      def declare_dlx_and_dlq
+        dlx_name = "#{EventPeople::Config::APP_NAME}_dlx"
+        dlq_name = "#{EventPeople::Config::APP_NAME}_dlq"
 
-        event = EventPeople::Event.new(event_name, payload)
-        context = EventPeople::Broker::Rabbit::RabbitContext.new(channel, delivery_info)
+        dlx = channel.fanout(dlx_name, durable: true)
+        channel.queue(dlq_name, durable: true).bind(dlx, routing_key: '')
+      end
+
+      def declare_retry_queue(main_queue_name)
+        channel.queue("#{main_queue_name}_retry", durable: true, arguments: {
+          'x-dead-letter-exchange'    => '',
+          'x-dead-letter-routing-key' => main_queue_name
+        })
+      end
+
+      def callback(delivery_info, properties, payload, queue_name, retry_config, &block)
+        event_name  = delivery_info.routing_key
+        retry_count = (properties.headers&.dig('x-event-people-retries') || 0).to_i
+
+        event = EventPeople::Event.new(event_name, payload, 1.0, retry_count: retry_count)
+
+        context = EventPeople::Broker::Rabbit::RabbitContext.new(
+          channel,
+          delivery_info,
+          retry_count:      retry_count,
+          max_retries:      retry_config[:max_attempts],
+          delay_strategy:   retry_config[:delay_strategy],
+          dlq_name:         retry_config[:dlq_name],
+          queue_name:       queue_name,
+          original_payload: payload
+        )
 
         block.call(event, context)
       end
@@ -38,8 +67,11 @@ module EventPeople
         Rabbit::Topic.topic(channel)
       end
 
-      def queue_options
-        { durable: true }
+      def main_queue_options
+        {
+          durable:   true,
+          arguments: { 'x-dead-letter-exchange' => "#{EventPeople::Config::APP_NAME}_dlx" }
+        }
       end
 
       def queue_name(routing_key)

--- a/lib/event_people/broker/rabbit/queue.rb
+++ b/lib/event_people/broker/rabbit/queue.rb
@@ -45,7 +45,7 @@ module EventPeople
 
       def callback(delivery_info, properties, payload, queue_name, retry_config, &block)
         event_name  = delivery_info.routing_key
-        retry_count = (properties.headers&.dig('x-event-people-retries') || 0).to_i
+        retry_count = [(properties.headers&.dig('x-event-people-retries') || 0).to_i, 0].max
 
         event = EventPeople::Event.new(event_name, payload, 1.0, retry_count: retry_count)
 

--- a/lib/event_people/broker/rabbit/rabbit_context.rb
+++ b/lib/event_people/broker/rabbit/rabbit_context.rb
@@ -1,9 +1,21 @@
 module EventPeople
   module Broker
     class Rabbit::RabbitContext < EventPeople::Broker::Context
-      def initialize(channel, delivery_info)
-        @channel = channel
-        @delivery_info = delivery_info
+      attr_reader :max_retries, :dlq_name
+
+      def initialize(channel, delivery_info, retry_count: 0, max_retries: nil, delay_strategy: nil, dlq_name: nil, queue_name: nil, original_payload: nil)
+        @channel          = channel
+        @delivery_info    = delivery_info
+        @retry_count      = retry_count.to_i
+        @max_retries      = (max_retries || EventPeople::Config::MAX_ATTEMPTS).to_i
+        @delay_strategy   = delay_strategy || EventPeople::Config::DELAY_STRATEGY
+        @dlq_name         = dlq_name || EventPeople::Config::DLQ_NAME
+        @queue_name       = queue_name
+        @original_payload = original_payload
+      end
+
+      def is_last_retry
+        @retry_count >= @max_retries - 1
       end
 
       def success
@@ -11,7 +23,20 @@ module EventPeople
       end
 
       def fail
-        @channel.nack(@delivery_info.delivery_tag, false, true)
+        retry_manager = Rabbit::RetryManager.new(@max_retries, @delay_strategy)
+
+        if retry_manager.should_retry?(@retry_count)
+          delay = retry_manager.get_next_delay(@retry_count)
+          @channel.default_exchange.publish(
+            @original_payload,
+            routing_key: "#{@queue_name}_retry",
+            expiration: delay.to_s,
+            headers: { 'x-event-people-retries' => @retry_count + 1 }
+          )
+          @channel.ack(@delivery_info.delivery_tag, false)
+        else
+          @channel.nack(@delivery_info.delivery_tag, false, false)
+        end
       end
 
       def reject

--- a/lib/event_people/broker/rabbit/rabbit_context.rb
+++ b/lib/event_people/broker/rabbit/rabbit_context.rb
@@ -27,13 +27,25 @@ module EventPeople
 
         if retry_manager.should_retry?(@retry_count)
           delay = retry_manager.get_next_delay(@retry_count)
-          @channel.default_exchange.publish(
-            @original_payload,
-            routing_key: "#{@queue_name}_retry",
-            expiration: delay.to_s,
-            headers: { 'x-event-people-retries' => @retry_count + 1 }
-          )
-          @channel.ack(@delivery_info.delivery_tag, false)
+          begin
+            @channel.default_exchange.publish(
+              @original_payload,
+              routing_key: "#{@queue_name}_retry",
+              expiration: delay.to_s,
+              headers: { 'x-event-people-retries' => @retry_count + 1 }
+            )
+            @channel.ack(@delivery_info.delivery_tag, false)
+          rescue => e
+            # If publish+ack fails, nack so the message is redelivered from the main queue.
+            # This risks duplication if publish succeeded but ack failed, which is an inherent
+            # AMQP at-least-once limitation. We prefer redelivery over silent loss.
+            begin
+              @channel.nack(@delivery_info.delivery_tag, false, true)
+            rescue
+              # Channel may already be closed; nothing we can do.
+            end
+            raise e
+          end
         else
           @channel.nack(@delivery_info.delivery_tag, false, false)
         end

--- a/lib/event_people/broker/rabbit/retry_manager.rb
+++ b/lib/event_people/broker/rabbit/retry_manager.rb
@@ -1,0 +1,25 @@
+module EventPeople
+  module Broker
+    class Rabbit::RetryManager
+      INITIAL_DELAY = (ENV['RABBIT_EVENT_PEOPLE_RETRY_TTL_MS'] || 1000).to_i
+      MAX_DELAY = 600_000
+
+      def initialize(max_attempts, delay_strategy = 'exponential')
+        @max_attempts   = max_attempts
+        @delay_strategy = delay_strategy
+      end
+
+      def should_retry?(retry_count)
+        retry_count < @max_attempts
+      end
+
+      def get_next_delay(retry_count)
+        if @delay_strategy == 'fixed'
+          INITIAL_DELAY
+        else
+          [INITIAL_DELAY * (5**retry_count), MAX_DELAY].min
+        end
+      end
+    end
+  end
+end

--- a/lib/event_people/config.rb
+++ b/lib/event_people/config.rb
@@ -6,8 +6,20 @@ module EventPeople
     URL      = ENV['RABBIT_URL']
     FULL_URL = "#{ENV['RABBIT_URL']}/#{ENV['RABBIT_EVENT_PEOPLE_VHOST']}"
 
+    MAX_ATTEMPTS   = (ENV['RABBIT_EVENT_PEOPLE_MAX_RETRIES'] || 3).to_i
+    DELAY_STRATEGY = 'exponential'
+    DLQ_NAME       = "#{ENV['RABBIT_EVENT_PEOPLE_APP_NAME']}_dlq"
+
     def self.broker
       EventPeople::Broker::Rabbit
+    end
+
+    def self.get_retry_config
+      {
+        max_attempts:   MAX_ATTEMPTS,
+        delay_strategy: DELAY_STRATEGY,
+        dlq_name:       DLQ_NAME
+      }
     end
   end
 end

--- a/lib/event_people/event.rb
+++ b/lib/event_people/event.rb
@@ -1,11 +1,12 @@
 module EventPeople
   class Event
-    attr_reader :name, :headers, :body, :schema_version
+    attr_reader :name, :headers, :body, :schema_version, :retry_count
 
-    def initialize(name, body, schema_version = 1.0)
+    def initialize(name, body, schema_version = 1.0, retry_count: 0)
       @name = name
       @body = body.is_a?(String) ? JSON.parse(body) : body
       @schema_version = @body&.dig('headers', 'schemaVersion') || schema_version
+      @retry_count = retry_count.to_i
 
       if name?
         generate_headers
@@ -13,6 +14,10 @@ module EventPeople
       end
 
       build_payload if @body&.key?('headers')
+    end
+
+    def increment_retry_count
+      @retry_count += 1
     end
 
     def payload

--- a/lib/event_people/listener.rb
+++ b/lib/event_people/listener.rb
@@ -2,16 +2,22 @@ require 'bunny'
 
 module EventPeople
   class Listener
-    def self.on(event_name, &block)
-      new.on(event_name, &block)
+    def self.on(event_name, max_attempts: nil, delay_strategy: nil, dlq_name: nil, &block)
+      new.on(event_name, max_attempts: max_attempts, delay_strategy: delay_strategy, dlq_name: dlq_name, &block)
     end
 
-    def on(event_name, &block)
+    def on(event_name, max_attempts: nil, delay_strategy: nil, dlq_name: nil, &block)
       raise(MissingAttributeError, 'Event name must be present') unless event_name&.size&.positive?
 
       event_name = consumed_event_name(event_name)
 
-      EventPeople::Config.broker.consume(event_name, &block)
+      retry_config = EventPeople::Config.get_retry_config.merge(
+        max_attempts:   max_attempts   || EventPeople::Config::MAX_ATTEMPTS,
+        delay_strategy: delay_strategy || EventPeople::Config::DELAY_STRATEGY,
+        dlq_name:       dlq_name       || EventPeople::Config::DLQ_NAME
+      )
+
+      EventPeople::Config.broker.consume(event_name, retry_config: retry_config, &block)
     end
 
     private

--- a/lib/event_people/listener.rb
+++ b/lib/event_people/listener.rb
@@ -11,11 +11,10 @@ module EventPeople
 
       event_name = consumed_event_name(event_name)
 
-      retry_config = EventPeople::Config.get_retry_config.merge(
-        max_attempts:   max_attempts   || EventPeople::Config::MAX_ATTEMPTS,
-        delay_strategy: delay_strategy || EventPeople::Config::DELAY_STRATEGY,
-        dlq_name:       dlq_name       || EventPeople::Config::DLQ_NAME
-      )
+      retry_config = EventPeople::Config.get_retry_config
+      retry_config[:max_attempts]   = max_attempts   unless max_attempts.nil?
+      retry_config[:delay_strategy] = delay_strategy unless delay_strategy.nil?
+      retry_config[:dlq_name]       = dlq_name       unless dlq_name.nil?
 
       EventPeople::Config.broker.consume(event_name, retry_config: retry_config, &block)
     end

--- a/lib/event_people/version.rb
+++ b/lib/event_people/version.rb
@@ -1,3 +1,3 @@
 module EventPeople
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/event_people/broker/base_spec.rb
+++ b/spec/event_people/broker/base_spec.rb
@@ -30,7 +30,7 @@ describe EventPeople::Broker::Base do
       end
 
       it 'calls consume on instance with correct parameters' do
-        expect_any_instance_of(described_class).to receive(:consume).with(event_name)
+        expect_any_instance_of(described_class).to receive(:consume).with(event_name, retry_config: {})
 
         subject
       end

--- a/spec/event_people/broker/rabbit/queue_spec.rb
+++ b/spec/event_people/broker/rabbit/queue_spec.rb
@@ -1,6 +1,18 @@
 describe EventPeople::Broker::Rabbit::Queue do
+  let(:app_name) { EventPeople::Config::APP_NAME.downcase }
+  let(:dlx_name) { "#{EventPeople::Config::APP_NAME}_dlx" }
+  let(:dlq_name) { "#{EventPeople::Config::APP_NAME}_dlq" }
+  let(:dlx_exchange) { double('dlx_exchange') }
+  let(:dlq_queue) { double('dlq_queue', bind: nil) }
+  let(:retry_queue) { double('retry_queue') }
   let(:instance) { described_class.new(connection) }
-  let(:connection) { double('conn', queue: bindable, prefetch: 1) }
+  let(:connection) do
+    double('conn',
+      prefetch: 1,
+      queue: bindable,
+      fanout: dlx_exchange
+    )
+  end
   let(:bindable) { double('bindable', bind: subscribable) }
   let(:subscribable) { double('subscribable', subscribe: block) }
   let(:topic) { 'topic' }
@@ -22,7 +34,7 @@ describe EventPeople::Broker::Rabbit::Queue do
 
   describe '.subscribe' do
     before do
-      allow(instance).to receive(:subscribe).with(routing_key)
+      allow(instance).to receive(:subscribe).with(routing_key, retry_config: {})
       allow(described_class).to receive(:new).with(connection).and_return(instance)
     end
 
@@ -35,24 +47,45 @@ describe EventPeople::Broker::Rabbit::Queue do
     end
 
     it 'calls subscribe on instance with correct parameters' do
-      expect(instance).to receive(:subscribe).with(routing_key)
+      expect(instance).to receive(:subscribe).with(routing_key, retry_config: {})
 
       subject
     end
   end
 
   describe '#subscribe' do
-    let(:queue_options) { { durable: true } }
-    let(:queue_name) { "#{EventPeople::Config::APP_NAME.downcase}-#{routing_key.downcase}.all" }
+    let(:main_queue_options) do
+      {
+        durable:   true,
+        arguments: { 'x-dead-letter-exchange' => dlx_name }
+      }
+    end
+    let(:queue_name) { "#{app_name}-#{routing_key.downcase}.all" }
+    let(:retry_queue_name) { "#{queue_name}_retry" }
 
     before do
       allow(EventPeople::Broker::Rabbit::Topic).to receive(:topic).and_return(topic)
+      # DLX / DLQ setup
+      allow(connection).to receive(:fanout).with(dlx_name, durable: true).and_return(dlx_exchange)
+      allow(connection).to receive(:queue).with(dlq_name, durable: true).and_return(dlq_queue)
+      allow(dlq_queue).to receive(:bind).with(dlx_exchange, routing_key: '')
+      # Retry queue
+      allow(connection).to receive(:queue).with(
+        retry_queue_name,
+        durable: true,
+        arguments: {
+          'x-dead-letter-exchange'    => '',
+          'x-dead-letter-routing-key' => queue_name
+        }
+      ).and_return(retry_queue)
+      # Main queue
+      allow(connection).to receive(:queue).with(queue_name, main_queue_options).and_return(bindable)
     end
 
     subject { instance.subscribe(routing_key, &block) }
 
     it 'instantiates a queue with correct attributes' do
-      expect(connection).to receive(:queue).with(queue_name, queue_options)
+      expect(connection).to receive(:queue).with(queue_name, main_queue_options).and_return(bindable)
 
       subject
     end
@@ -71,25 +104,25 @@ describe EventPeople::Broker::Rabbit::Queue do
 
     context 'when message is received' do
       let(:event_name) { 'event_name' }
-      let(:delivery_info) { double('delivery_info', routing_key: event_name) }
-      let(:properties) { 'properties' }
-      let(:payload) { 'payload' }
+      let(:delivery_info) { double('delivery_info', routing_key: event_name, delivery_tag: 1) }
+      let(:headers_hash) { nil }
+      let(:properties) { double('properties', headers: headers_hash) }
+      let(:payload) { '{"headers":{},"body":{}}' }
       let(:context) { double(EventPeople::Broker::Rabbit::RabbitContext) }
       let(:subscribe_block) do
         ->(delivery_info, properties, payload) do
-          instance.send(:callback, delivery_info, properties, payload, &block)
+          instance.send(:callback, delivery_info, properties, payload, queue_name, {}, &block)
         end
       end
 
       before do
-        allow(EventPeople::Event).to receive(:new).with(event_name, payload).and_return(event)
-        allow(EventPeople::Broker::Rabbit::RabbitContext).to receive(:new).with(connection, delivery_info).and_return(context)
+        allow(EventPeople::Broker::Rabbit::RabbitContext).to receive(:new).and_return(context)
       end
 
       it 'calls block with the received event and context' do
         subject
 
-        expect(block).to receive(:call).with(event, context)
+        expect(block).to receive(:call).with(instance_of(EventPeople::Event), context)
 
         subscribe_block.call(delivery_info, properties, payload)
       end

--- a/spec/event_people/broker/rabbit/rabbit_context_spec.rb
+++ b/spec/event_people/broker/rabbit/rabbit_context_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe EventPeople::Broker::Rabbit::RabbitContext do
+  let(:channel)       { double('channel') }
+  let(:delivery_info) { double('delivery_info', delivery_tag: 42) }
+
+  def build_context(retry_count:, max_retries:)
+    described_class.new(
+      channel,
+      delivery_info,
+      retry_count:      retry_count,
+      max_retries:      max_retries,
+      delay_strategy:   'fixed',
+      dlq_name:         'test_dlq',
+      queue_name:       'test_queue',
+      original_payload: '{}'
+    )
+  end
+
+  describe '#is_last_retry' do
+    it 'returns false when not on last attempt' do
+      context = build_context(retry_count: 0, max_retries: 3)
+      expect(context.is_last_retry).to be false
+    end
+
+    it 'returns true on last attempt (retry_count == max_retries - 1)' do
+      context = build_context(retry_count: 2, max_retries: 3)
+      expect(context.is_last_retry).to be true
+    end
+  end
+end

--- a/spec/event_people/broker/rabbit/retry_manager_spec.rb
+++ b/spec/event_people/broker/rabbit/retry_manager_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe EventPeople::Broker::Rabbit::RetryManager do
+  describe '#should_retry?' do
+    it 'returns true when retry_count < max_retries' do
+      expect(described_class.new(3).should_retry?(2)).to be true
+    end
+    it 'returns false when retry_count == max_retries' do
+      expect(described_class.new(3).should_retry?(3)).to be false
+    end
+    it 'returns false when retry_count > max_retries' do
+      expect(described_class.new(3).should_retry?(5)).to be false
+    end
+  end
+
+  describe '#get_next_delay' do
+    context 'exponential strategy' do
+      subject { described_class.new(3, 'exponential') }
+      it 'uses initialDelay * 5^0 for retry 0' do
+        expect(subject.get_next_delay(0)).to eq(described_class::INITIAL_DELAY)
+      end
+      it 'uses initialDelay * 5^1 for retry 1' do
+        expect(subject.get_next_delay(1)).to eq(described_class::INITIAL_DELAY * 5)
+      end
+      it 'caps at MAX_DELAY' do
+        expect(subject.get_next_delay(100)).to eq(described_class::MAX_DELAY)
+      end
+    end
+
+    context 'fixed strategy' do
+      subject { described_class.new(3, 'fixed') }
+      it 'always returns INITIAL_DELAY' do
+        expect(subject.get_next_delay(0)).to eq(described_class::INITIAL_DELAY)
+        expect(subject.get_next_delay(5)).to eq(described_class::INITIAL_DELAY)
+      end
+    end
+  end
+end

--- a/spec/event_people/broker/rabbit_spec.rb
+++ b/spec/event_people/broker/rabbit_spec.rb
@@ -62,7 +62,7 @@ describe EventPeople::Broker::Rabbit do
     subject { instance.consume(event_name, &block) }
 
     it 'calls subscribe on Rabbit Queue class' do
-      expect(EventPeople::Broker::Rabbit::Queue).to receive(:subscribe).with(channel, event_name)
+      expect(EventPeople::Broker::Rabbit::Queue).to receive(:subscribe).with(channel, event_name, retry_config: {})
 
       subject
     end

--- a/spec/event_people/listener_spec.rb
+++ b/spec/event_people/listener_spec.rb
@@ -1,18 +1,25 @@
 describe EventPeople::Listener do
   let(:event_name) { 'resource.origin.action' }
   let(:consumed_event_name) { 'resource.origin.action.all' }
-  let(:block) { ->(_) { true } }
+  let(:block) { ->(event, context) { true } }
+  let(:retry_config) do
+    {
+      max_attempts:   EventPeople::Config::MAX_ATTEMPTS,
+      delay_strategy: EventPeople::Config::DELAY_STRATEGY,
+      dlq_name:       EventPeople::Config::DLQ_NAME
+    }
+  end
 
   describe '.on' do
     before do
-      allow(EventPeople::Config.broker).to receive(:consume).with(consumed_event_name, &block)
+      allow(EventPeople::Config.broker).to receive(:consume)
     end
 
     subject { described_class.on(event_name, &block) }
 
     context 'when event name is present' do
       it 'consumes the event on the broker' do
-        expect(EventPeople::Config.broker).to receive(:consume).with(consumed_event_name, &block)
+        expect(EventPeople::Config.broker).to receive(:consume).with(consumed_event_name, retry_config: retry_config)
 
         subject
       end
@@ -25,7 +32,7 @@ describe EventPeople::Listener do
         let(:consumed_event_name) { 'resource.origin.action.all' }
 
         it 'consumes the event with destination on the broker' do
-          expect(EventPeople::Config.broker).to receive(:consume).with(consumed_event_name, &block)
+          expect(EventPeople::Config.broker).to receive(:consume).with(consumed_event_name, retry_config: retry_config)
 
           subject
         end

--- a/spec/event_people_spec.rb
+++ b/spec/event_people_spec.rb
@@ -1,5 +1,5 @@
 describe EventPeople do
   it 'has a version number' do
-    expect(EventPeople::VERSION).to eq '1.0.7'
+    expect(EventPeople::VERSION).to eq '1.2.0'
   end
 end


### PR DESCRIPTION
## Summary

- Implements `RetryManager` with exponential and fixed backoff strategies
- Adds DLX/DLQ topology: main queue routes dead letters to `{app_name}_dlx` fanout → `{app_name}_dlq`
- Adds per-message retry queue (`{queue_name}_retry`) with TTL-based expiration via `x-message-ttl`-free approach (expiration set per-message on publish)
- Extends `Event` with `retry_count` attribute (populated from `x-event-people-retries` AMQP header) and `increment_retry_count()`
- Extends `Config` with `MAX_ATTEMPTS`, `DELAY_STRATEGY`, `DLQ_NAME` constants and `get_retry_config()` class method
- Extends `Listener.on` with optional `max_attempts:`, `delay_strategy:`, `dlq_name:` keyword args
- Adds abstract `max_retries` and `is_last_retry` to `Context`; implements both in `RabbitContext`
- Changes `RabbitContext#fail`: retries via retry queue if `retry_count < max_retries`, otherwise nacks without requeue (routes to DLQ via DLX)
- Bumps gem version `1.1.0` → `1.2.0` (MINOR — new backward-compatible feature)
- Updates `.event_people.yml`: all retry items moved from `pending` to `implemented`

## Test plan

- [ ] All 78 existing specs pass (`bundle exec rspec`)
- [ ] Verify retry queue declared with `x-dead-letter-exchange: ""` and `x-dead-letter-routing-key: {main_queue}`
- [ ] Verify main queue declared with `x-dead-letter-exchange: {app_name}_dlx`
- [ ] Verify exponential delay formula: `INITIAL_DELAY * 5^retry_count`, capped at 600_000ms
- [ ] Verify fixed delay returns `INITIAL_DELAY` regardless of retry count
- [ ] Verify `fail()` acks after publishing to retry queue on retryable errors
- [ ] Verify `fail()` nacks (no requeue) after exhausting retries, routing message to DLQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)