### PR TITLE
fix: nack(requeue=false) on retry-publish failure

### DIFF
--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,5 +1,5 @@
-spec_version: "1.1.0"
-implementation_version: "1.2.0"
+spec_version: "1.1.1"
+implementation_version: "1.2.1"
 language: ruby
 package: "event_people (RubyGems)"
 status: stable

--- a/lib/event_people/broker/rabbit/rabbit_context.rb
+++ b/lib/event_people/broker/rabbit/rabbit_context.rb
@@ -40,7 +40,7 @@ module EventPeople
             # This risks duplication if publish succeeded but ack failed, which is an inherent
             # AMQP at-least-once limitation. We prefer redelivery over silent loss.
             begin
-              @channel.nack(@delivery_info.delivery_tag, false, true)
+              @channel.nack(@delivery_info.delivery_tag, false, false)
             rescue
               # Channel may already be closed; nothing we can do.
             end

--- a/lib/event_people/broker/rabbit/rabbit_context.rb
+++ b/lib/event_people/broker/rabbit/rabbit_context.rb
@@ -34,9 +34,8 @@ module EventPeople
               expiration: delay.to_s,
               headers: { 'x-event-people-retries' => @retry_count + 1 }
             )
-            @channel.ack(@delivery_info.delivery_tag, false)
           rescue => e
-            # If publish+ack fails, nack without requeue so the DLX routes to DLQ.
+            # Publish failed — nack without requeue so the DLX routes to DLQ.
             # Requeuing without incrementing x-event-people-retries would cause an infinite loop.
             begin
               @channel.nack(@delivery_info.delivery_tag, false, false)
@@ -44,6 +43,13 @@ module EventPeople
               # Channel may already be closed; nothing we can do.
             end
             raise e
+          end
+          begin
+            @channel.ack(@delivery_info.delivery_tag, false)
+          rescue
+            # Publish already succeeded; swallow ack errors. The message may be redelivered
+            # once (at-least-once), but that is safer than nacking to DLQ when a retry copy
+            # is already enqueued.
           end
         else
           @channel.nack(@delivery_info.delivery_tag, false, false)

--- a/lib/event_people/broker/rabbit/rabbit_context.rb
+++ b/lib/event_people/broker/rabbit/rabbit_context.rb
@@ -36,9 +36,8 @@ module EventPeople
             )
             @channel.ack(@delivery_info.delivery_tag, false)
           rescue => e
-            # If publish+ack fails, nack so the message is redelivered from the main queue.
-            # This risks duplication if publish succeeded but ack failed, which is an inherent
-            # AMQP at-least-once limitation. We prefer redelivery over silent loss.
+            # If publish+ack fails, nack without requeue so the DLX routes to DLQ.
+            # Requeuing without incrementing x-event-people-retries would cause an infinite loop.
             begin
               @channel.nack(@delivery_info.delivery_tag, false, false)
             rescue


### PR DESCRIPTION
When publishing to the retry queue fails, fall back to nack(requeue=false) instead of nack(requeue=true). Requeuing without incrementing x-event-people-retries causes an infinite redelivery loop (SOPHIA-1G). Implements spec v1.1.1.