### PR TITLE
feat: implement EventPeople spec v1.2.0

### DIFF
--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,5 +1,5 @@
-spec_version: "1.1.1"
-implementation_version: "1.2.1"
+spec_version: "1.2.0"
+implementation_version: "1.2.0"
 language: ruby
 package: "event_people (RubyGems)"
 status: stable
@@ -22,11 +22,15 @@ implemented:
   - RetryManager
   - "Event.retryCount"
   - "Event.incrementRetryCount"
+  - "Config.configure"
   - "Config.maxAttempts"
+  - "Config.initialDelay"
   - "Config.delayStrategy"
   - "Config.dlqName"
   - "Config.getRetryConfig"
-  - "Listener.on (retry params: maxAttempts, delayStrategy, dlqName)"
+  - "Listener.on (eventName, callback) — retry params removed per v1.2.0"
+  - "BaseListener class-level retry attributes: maxAttempts, initialDelay, delayStrategy, dlqName"
+  - "BaseListener.context instance accessor"
   - "Context.maxRetries"
   - "Context.isLastRetry"
   - "RabbitContext.maxRetries"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# EventPeople — Ruby Implementation
+
+Spec version target: see `.event_people.yml` → `spec_version`
+Spec contract: `spec/contract.yml` in the main `event_people` repository
+GitHub: https://github.com/pin-people/event_people_ruby
+
+## Project Structure
+
+```
+lib/event_people/
+├── config.rb
+├── event.rb
+├── listener.rb
+├── emitter.rb
+├── daemon.rb
+├── broker/
+│   ├── base.rb          ← BaseBroker interface
+│   ├── context.rb       ← Context interface
+│   └── rabbit/
+│       ├── rabbit_context.rb
+│       ├── topic.rb
+│       └── queue.rb
+└── listeners/
+    ├── base.rb          ← BaseListener
+    └── manager.rb       ← ListenersManager
+```
+
+## Critical Rule — Spec Conformance
+
+**Before implementing any new feature or changing existing behavior:**
+
+1. Check `spec/contract.yml` in the main repo for the expected interface definition
+2. Check `.event_people.yml` for known deviations already accepted in this implementation
+
+If the change **aligns with the spec**: implement and update `.event_people.yml` status accordingly.
+
+If the change **would deviate from the spec** (different method name, different signature,
+different attribute, different behavior):
+
+→ **STOP and ask the user:**
+> "This change deviates from spec/contract.yml. Should we:
+> 1. Update the spec first (via /update-spec in the main repo), then implement here?
+> 2. Conform to the current spec instead?"
+
+Never implement a deviation silently.
+
+## Known Deviations
+
+See `.event_people.yml` → `deviations` section. Currently clean.
+
+> The bang-method deviation (DEV-RB-001) was resolved — `success`, `fail`, `reject` are now the
+> primary interface. The `success!`, `fail!`, `reject!` aliases remain but emit deprecation warnings.
+
+## Known Bugs
+
+See `.event_people.yml` → `bugs` section. Currently clean.
+
+## Pending Features
+
+None — all spec v1.2.0 components are implemented.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Spec version target: see `.event_people.yml` → `spec_version`
 Spec contract: `spec/contract.yml` in the main `event_people` repository
-GitHub: https://github.com/pin-people/event_people_ruby
+GitHub: <https://github.com/pin-people/event_people_ruby>
 
 ## Project Structure
 
@@ -30,6 +30,7 @@ lib/event_people/
 **Before implementing any new feature or changing existing behavior:**
 
 1. Check `spec/contract.yml` in the main repo for the expected interface definition
+
 2. Check `.event_people.yml` for known deviations already accepted in this implementation
 
 If the change **aligns with the spec**: implement and update `.event_people.yml` status accordingly.
@@ -38,8 +39,11 @@ If the change **would deviate from the spec** (different method name, different 
 different attribute, different behavior):
 
 → **STOP and ask the user:**
+
 > "This change deviates from spec/contract.yml. Should we:
+>
 > 1. Update the spec first (via /update-spec in the main repo), then implement here?
+>
 > 2. Conform to the current spec instead?"
 
 Never implement a deviation silently.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ We follow the RabbitMQ pattern matching model, so given each word of the event n
 
 Other important aspect of event consumming is the result of the processing we provide 3 methods so you can inform the Broker what to do with the event next:
 
-- `success!:` should be called when the event was processed successfuly and the can be discarded;
-- `fail!:` should be called when an error ocurred processing the event and the message should be requeued;
-- `reject!:` should be called whenever a message should be discarded without being processed.
+- `success:` should be called when the event was processed successfuly and can be discarded;
+- `fail:` should be called when an error ocurred processing the event and the message should be retried or dead-lettered;
+- `reject:` should be called whenever a message should be discarded without being processed (routes directly to DLQ).
 
 Given you want to consume a single event inside your project you can use the `EventPeople::Listener.on` method. It consumes a single event, given there are events available to be consumed with the given name pattern.
 
@@ -108,7 +108,7 @@ EventPeople::Listener.on(event_name) do |event, context|
   puts "  - Received the "#{event.name}" message from #{event.origin}:"
   puts "     Message: #{event.body}"
   puts ""
-  context.success!
+  context.success
 end
 
 EventPeople::Config.broker.close_connection
@@ -131,7 +131,7 @@ while has_events do
     puts "  - Received the "#{event.name}" message from #{event.origin}:"
     puts "     Message: #{event.body}"
     puts ""
-    context.success!
+    context.success
   end
 end
 
@@ -154,7 +154,7 @@ class CustomEventListener < EventPeople::Listeners::Base
   def pay(event)
     puts "Paid #{event.body['amount']} for #{event.body['name']} ~> #{event.name}"
 
-    success!
+    success
   end
 
   def receive(event)
@@ -162,16 +162,16 @@ class CustomEventListener < EventPeople::Listeners::Base
       puts "Received #{event.body['amount']} from #{event.body['name']} ~> #{event.name}"
     else
       puts '[consumer] Got SKIPPED message'
-      return reject!
+      return reject
     end
 
-    success!
+    success
   end
 
   def private_channel(event)
     puts "[consumer] Got a private message: \"#{event.body['message']}\" ~> #{event.name}"
 
-    success!
+    success
   end
 end
 ```
@@ -222,18 +222,47 @@ EventPeople::Daemon.start
 
 ## Retry and Dead Letter Queue (DLQ)
 
-### Environment variables
+### Configuration
 
-| Variable | Description | Default |
-|---|---|---|
-| `RABBIT_EVENT_PEOPLE_MAX_RETRIES` | Max retry attempts before dead-lettering | `3` |
-| `RABBIT_EVENT_PEOPLE_RETRY_TTL_MS` | Base delay in ms for retry backoff | `1000` |
+Retry behaviour is configured in code, not via environment variables (since v1.2.0):
+
+```ruby
+# Optional: set global retry defaults (call once at boot time)
+EventPeople::Config.configure(
+  max_attempts:   5,          # default: 3
+  initial_delay:  500,        # default: 1000 ms
+  delay_strategy: 'fixed',   # default: 'exponential'
+  dlq_name:       'my_dlq'   # default: '{app_name}_dlq'
+)
+```
+
+Connection attributes (`RABBIT_URL`, `RABBIT_EVENT_PEOPLE_APP_NAME`, etc.) are still read from environment variables.
+
+### Per-listener override
+
+Retry settings can also be declared directly on a listener class, which overrides the global Config defaults for that listener:
+
+```ruby
+class OrderListener < EventPeople::Listeners::Base
+  self.max_attempts   = 5
+  self.initial_delay  = 500
+  self.delay_strategy = 'fixed'
+  self.dlq_name       = 'orders_dlq'
+
+  bind :handle_created, 'order.service.created'
+
+  def handle_created(event)
+    # ...
+  end
+end
+```
 
 ### How it works
 
 On `context.fail`:
 - If retries remain → message published to `{queue}_retry` with exponential backoff delay, then acked
 - If retries exhausted → nacked to DLQ via RabbitMQ DLX
+- If publish to retry queue fails → nacked to DLQ (never requeued, to avoid infinite loops)
 
 On `context.reject` → nacked directly to DLQ (no retries)
 
@@ -270,11 +299,6 @@ class OrderListener < EventPeople::Listeners::Base
     fail  # → retry queue (or DLQ if exhausted)
   end
 end
-
-# Per-listener retry config (overrides env var defaults)
-EventPeople::Listener.on('order.service.created', method(:handle),
-                         max_attempts: 5,
-                         delay_strategy: 'exponential')
 ```
 
 > **Note:** `success!`, `fail!`, `reject!` still work but are deprecated — prefer `success`, `fail`, `reject`.

--- a/lib/event_people/broker/rabbit/queue.rb
+++ b/lib/event_people/broker/rabbit/queue.rb
@@ -54,6 +54,7 @@ module EventPeople
           delivery_info,
           retry_count:      retry_count,
           max_retries:      retry_config[:max_attempts],
+          initial_delay:    retry_config[:initial_delay],
           delay_strategy:   retry_config[:delay_strategy],
           dlq_name:         retry_config[:dlq_name],
           queue_name:       queue_name,

--- a/lib/event_people/broker/rabbit/rabbit_context.rb
+++ b/lib/event_people/broker/rabbit/rabbit_context.rb
@@ -3,13 +3,14 @@ module EventPeople
     class Rabbit::RabbitContext < EventPeople::Broker::Context
       attr_reader :max_retries, :dlq_name
 
-      def initialize(channel, delivery_info, retry_count: 0, max_retries: nil, delay_strategy: nil, dlq_name: nil, queue_name: nil, original_payload: nil)
+      def initialize(channel, delivery_info, retry_count: 0, max_retries: nil, initial_delay: nil, delay_strategy: nil, dlq_name: nil, queue_name: nil, original_payload: nil)
         @channel          = channel
         @delivery_info    = delivery_info
         @retry_count      = retry_count.to_i
-        @max_retries      = (max_retries || EventPeople::Config::MAX_ATTEMPTS).to_i
-        @delay_strategy   = delay_strategy || EventPeople::Config::DELAY_STRATEGY
-        @dlq_name         = dlq_name || EventPeople::Config::DLQ_NAME
+        @max_retries      = (max_retries || EventPeople::Config.max_attempts).to_i
+        @initial_delay    = initial_delay || EventPeople::Config.initial_delay
+        @delay_strategy   = delay_strategy || EventPeople::Config.delay_strategy
+        @dlq_name         = dlq_name || EventPeople::Config.dlq_name
         @queue_name       = queue_name
         @original_payload = original_payload
       end
@@ -23,7 +24,7 @@ module EventPeople
       end
 
       def fail
-        retry_manager = Rabbit::RetryManager.new(@max_retries, @delay_strategy)
+        retry_manager = Rabbit::RetryManager.new(@max_retries, @delay_strategy, initial_delay: @initial_delay)
 
         if retry_manager.should_retry?(@retry_count)
           delay = retry_manager.get_next_delay(@retry_count)

--- a/lib/event_people/broker/rabbit/retry_manager.rb
+++ b/lib/event_people/broker/rabbit/retry_manager.rb
@@ -1,12 +1,12 @@
 module EventPeople
   module Broker
     class Rabbit::RetryManager
-      INITIAL_DELAY = (ENV['RABBIT_EVENT_PEOPLE_RETRY_TTL_MS'] || 1000).to_i
       MAX_DELAY = 600_000
 
-      def initialize(max_attempts, delay_strategy = 'exponential')
+      def initialize(max_attempts, delay_strategy = 'exponential', initial_delay: nil)
         @max_attempts   = max_attempts
         @delay_strategy = delay_strategy
+        @initial_delay  = initial_delay || EventPeople::Config.initial_delay
       end
 
       def should_retry?(retry_count)
@@ -15,9 +15,9 @@ module EventPeople
 
       def get_next_delay(retry_count)
         if @delay_strategy == 'fixed'
-          INITIAL_DELAY
+          @initial_delay
         else
-          [INITIAL_DELAY * (5**retry_count), MAX_DELAY].min
+          [@initial_delay * (5**retry_count), MAX_DELAY].min
         end
       end
     end

--- a/lib/event_people/config.rb
+++ b/lib/event_people/config.rb
@@ -6,20 +6,50 @@ module EventPeople
     URL      = ENV['RABBIT_URL']
     FULL_URL = "#{ENV['RABBIT_URL']}/#{ENV['RABBIT_EVENT_PEOPLE_VHOST']}"
 
-    MAX_ATTEMPTS   = (ENV['RABBIT_EVENT_PEOPLE_MAX_RETRIES'] || 3).to_i
-    DELAY_STRATEGY = 'exponential'
-    DLQ_NAME       = "#{ENV['RABBIT_EVENT_PEOPLE_APP_NAME']}_dlq"
+    # Hardcoded defaults — no longer sourced from env vars (spec v1.2.0).
+    DEFAULT_MAX_ATTEMPTS   = 3
+    DEFAULT_INITIAL_DELAY  = 1000
+    DEFAULT_DELAY_STRATEGY = 'exponential'
 
-    def self.broker
-      EventPeople::Broker::Rabbit
-    end
+    class << self
+      # Optional. Sets global retry defaults in code.
+      # Options: { max_attempts, initial_delay, delay_strategy, dlq_name }
+      # Connection attributes (app_name, url, vhost, topic) are always read from env vars.
+      def configure(options = {})
+        @max_attempts   = options[:max_attempts]&.to_i
+        @initial_delay  = options[:initial_delay]&.to_i
+        @delay_strategy = options[:delay_strategy]
+        @dlq_name       = options[:dlq_name]
+      end
 
-    def self.get_retry_config
-      {
-        max_attempts:   MAX_ATTEMPTS,
-        delay_strategy: DELAY_STRATEGY,
-        dlq_name:       DLQ_NAME
-      }
+      def max_attempts
+        @max_attempts || DEFAULT_MAX_ATTEMPTS
+      end
+
+      def initial_delay
+        @initial_delay || DEFAULT_INITIAL_DELAY
+      end
+
+      def delay_strategy
+        @delay_strategy || DEFAULT_DELAY_STRATEGY
+      end
+
+      def dlq_name
+        @dlq_name || "#{APP_NAME}_dlq"
+      end
+
+      def broker
+        EventPeople::Broker::Rabbit
+      end
+
+      def get_retry_config
+        {
+          max_attempts:   max_attempts,
+          initial_delay:  initial_delay,
+          delay_strategy: delay_strategy,
+          dlq_name:       dlq_name
+        }
+      end
     end
   end
 end

--- a/lib/event_people/listener.rb
+++ b/lib/event_people/listener.rb
@@ -2,19 +2,16 @@ require 'bunny'
 
 module EventPeople
   class Listener
-    def self.on(event_name, max_attempts: nil, delay_strategy: nil, dlq_name: nil, &block)
-      new.on(event_name, max_attempts: max_attempts, delay_strategy: delay_strategy, dlq_name: dlq_name, &block)
+    def self.on(event_name, listener_class: nil, &block)
+      new.on(event_name, listener_class: listener_class, &block)
     end
 
-    def on(event_name, max_attempts: nil, delay_strategy: nil, dlq_name: nil, &block)
+    def on(event_name, listener_class: nil, &block)
       raise(MissingAttributeError, 'Event name must be present') unless event_name&.size&.positive?
 
       event_name = consumed_event_name(event_name)
 
-      retry_config = EventPeople::Config.get_retry_config
-      retry_config[:max_attempts]   = max_attempts   unless max_attempts.nil?
-      retry_config[:delay_strategy] = delay_strategy unless delay_strategy.nil?
-      retry_config[:dlq_name]       = dlq_name       unless dlq_name.nil?
+      retry_config = retry_config_for(listener_class)
 
       EventPeople::Config.broker.consume(event_name, retry_config: retry_config, &block)
     end
@@ -23,6 +20,16 @@ module EventPeople
 
     def consumed_event_name(event_name)
       event_name.split('.').size == 3 ? "#{event_name}.all" : event_name
+    end
+
+    # Resolve retry config: listener class attributes > Config defaults.
+    def retry_config_for(listener_class)
+      base = EventPeople::Config.get_retry_config
+
+      return base unless listener_class.respond_to?(:retry_config)
+
+      listener_config = listener_class.retry_config
+      base.merge(listener_config.reject { |_, v| v.nil? })
     end
   end
 end

--- a/lib/event_people/listeners/base.rb
+++ b/lib/event_people/listeners/base.rb
@@ -1,6 +1,85 @@
 module EventPeople
   module Listeners
     class Base
+      # ---------------------------------------------------------------------------
+      # Class-level retry DSL (spec v1.2.0)
+      # Subclasses may declare any of these to override Config defaults:
+      #
+      #   class MyListener < EventPeople::Listeners::Base
+      #     self.max_attempts   = 5
+      #     self.initial_delay  = 500
+      #     self.delay_strategy = 'fixed'
+      #     self.dlq_name       = 'my_dlq'
+      #   end
+      # ---------------------------------------------------------------------------
+      class << self
+        attr_writer :max_attempts, :initial_delay, :delay_strategy, :dlq_name
+
+        def max_attempts;   defined?(@max_attempts)   ? @max_attempts   : nil; end
+        def initial_delay;  defined?(@initial_delay)  ? @initial_delay  : nil; end
+        def delay_strategy; defined?(@delay_strategy) ? @delay_strategy : nil; end
+        def dlq_name;       defined?(@dlq_name)       ? @dlq_name       : nil; end
+
+        # Returns only explicitly set class-level retry attrs (nils excluded by Listener).
+        def retry_config
+          {
+            max_attempts:   max_attempts,
+            initial_delay:  initial_delay,
+            delay_strategy: delay_strategy,
+            dlq_name:       dlq_name
+          }
+        end
+
+        def bind(method, event_name)
+          app_name = ENV['RABBIT_EVENT_PEOPLE_APP_NAME'].downcase
+          splitted_event_name = event_name.split('.')
+
+          if splitted_event_name.size <= 3
+            Manager.register_listener_configuration(
+              {
+                listener_class: self,
+                method: method,
+                routing_key: fixed_event_name(event_name, 'all')
+              }
+            )
+            Manager.register_listener_configuration(
+              {
+                listener_class: self,
+                method: method,
+                routing_key: fixed_event_name(event_name, app_name)
+              }
+            )
+          else
+            Manager.register_listener_configuration(
+              {
+                listener_class: self,
+                method: method,
+                routing_key: fixed_event_name(event_name, app_name)
+              }
+            )
+          end
+        end
+
+        def fixed_event_name(event_name, postfix)
+          case event_name&.split('.')&.size
+          when 4
+            parts = event_name.split('.')
+
+            "#{parts[0..2].join('.')}.#{postfix}"
+          when nil
+            event_name
+          else
+            "#{event_name}.#{postfix}"
+          end
+        end
+      end
+
+      # ---------------------------------------------------------------------------
+      # Instance interface
+      # ---------------------------------------------------------------------------
+
+      attr_reader :context
+
       def initialize(context)
         @context = context
       end
@@ -34,49 +113,6 @@ module EventPeople
       def reject!
         warn '[DEPRECATED] EventPeople: `reject!` is deprecated, use `reject` instead. Will be removed in a future version.'
         reject
-      end
-
-      def self.bind(method, event_name)
-        app_name = ENV['RABBIT_EVENT_PEOPLE_APP_NAME'].downcase
-        splitted_event_name = event_name.split('.')
-
-        if splitted_event_name.size <= 3
-          Manager.register_listener_configuration(
-            {
-              listener_class: self,
-              method: method,
-              routing_key: fixed_event_name(event_name, 'all')
-            }
-          )
-          Manager.register_listener_configuration(
-            {
-              listener_class: self,
-              method: method,
-              routing_key: fixed_event_name(event_name, app_name)
-            }
-          )
-        else
-          Manager.register_listener_configuration(
-            {
-              listener_class: self,
-              method: method,
-              routing_key: fixed_event_name(event_name, app_name)
-            }
-          )
-        end
-      end
-
-      def self.fixed_event_name(event_name, postfix)
-        case event_name&.split('.')&.size
-        when 4
-          parts = event_name.split('.')
-
-          "#{parts[0..2].join('.')}.#{postfix}"
-        when nil
-          event_name
-        else
-          "#{event_name}.#{postfix}"
-        end
       end
     end
   end

--- a/lib/event_people/listeners/manager.rb
+++ b/lib/event_people/listeners/manager.rb
@@ -5,7 +5,7 @@ module EventPeople
       class << self
         def bind_all_listeners
           listener_configurations.each do |config|
-            EventPeople::Listener.on(config[:routing_key]) do |event, context|
+            EventPeople::Listener.on(config[:routing_key], listener_class: config[:listener_class]) do |event, context|
               config[:listener_class].new(context).callback(config[:method], event)
             end
           end

--- a/lib/event_people/version.rb
+++ b/lib/event_people/version.rb
@@ -1,3 +1,3 @@
 module EventPeople
-  VERSION = '1.2.1'
+  VERSION = '1.2.0'
 end

--- a/spec/event_people/broker/rabbit/retry_manager_spec.rb
+++ b/spec/event_people/broker/rabbit/retry_manager_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe EventPeople::Broker::Rabbit::RetryManager do
+  let(:default_initial_delay) { EventPeople::Config::DEFAULT_INITIAL_DELAY }
+
   describe '#should_retry?' do
     it 'returns true when retry_count < max_retries' do
       expect(described_class.new(3).should_retry?(2)).to be true
@@ -14,22 +16,44 @@ RSpec.describe EventPeople::Broker::Rabbit::RetryManager do
   describe '#get_next_delay' do
     context 'exponential strategy' do
       subject { described_class.new(3, 'exponential') }
+
       it 'uses initialDelay * 5^0 for retry 0' do
-        expect(subject.get_next_delay(0)).to eq(described_class::INITIAL_DELAY)
+        expect(subject.get_next_delay(0)).to eq(default_initial_delay)
       end
+
       it 'uses initialDelay * 5^1 for retry 1' do
-        expect(subject.get_next_delay(1)).to eq(described_class::INITIAL_DELAY * 5)
+        expect(subject.get_next_delay(1)).to eq(default_initial_delay * 5)
       end
+
       it 'caps at MAX_DELAY' do
         expect(subject.get_next_delay(100)).to eq(described_class::MAX_DELAY)
+      end
+
+      context 'when a custom initial_delay is provided' do
+        subject { described_class.new(3, 'exponential', initial_delay: 500) }
+
+        it 'uses the custom initial_delay' do
+          expect(subject.get_next_delay(0)).to eq(500)
+          expect(subject.get_next_delay(1)).to eq(500 * 5)
+        end
       end
     end
 
     context 'fixed strategy' do
       subject { described_class.new(3, 'fixed') }
-      it 'always returns INITIAL_DELAY' do
-        expect(subject.get_next_delay(0)).to eq(described_class::INITIAL_DELAY)
-        expect(subject.get_next_delay(5)).to eq(described_class::INITIAL_DELAY)
+
+      it 'always returns the default initial_delay' do
+        expect(subject.get_next_delay(0)).to eq(default_initial_delay)
+        expect(subject.get_next_delay(5)).to eq(default_initial_delay)
+      end
+
+      context 'when a custom initial_delay is provided' do
+        subject { described_class.new(3, 'fixed', initial_delay: 250) }
+
+        it 'always returns the custom initial_delay' do
+          expect(subject.get_next_delay(0)).to eq(250)
+          expect(subject.get_next_delay(5)).to eq(250)
+        end
       end
     end
   end

--- a/spec/event_people/config_spec.rb
+++ b/spec/event_people/config_spec.rb
@@ -1,4 +1,9 @@
 describe EventPeople::Config do
+  # Reset class-level state after each example so tests remain isolated.
+  after do
+    described_class.configure
+  end
+
   it 'has an app name config' do
     expect(EventPeople::Config::APP_NAME).to eq 'app_name'
   end
@@ -21,5 +26,89 @@ describe EventPeople::Config do
 
   it 'has a broker config' do
     expect(EventPeople::Config.broker).to eq EventPeople::Broker::Rabbit
+  end
+
+  describe '.max_attempts' do
+    it 'returns the default value when configure has not been called' do
+      expect(described_class.max_attempts).to eq EventPeople::Config::DEFAULT_MAX_ATTEMPTS
+    end
+
+    it 'returns the configured value when configure has been called' do
+      described_class.configure(max_attempts: 7)
+      expect(described_class.max_attempts).to eq 7
+    end
+  end
+
+  describe '.initial_delay' do
+    it 'returns the default value when configure has not been called' do
+      expect(described_class.initial_delay).to eq EventPeople::Config::DEFAULT_INITIAL_DELAY
+    end
+
+    it 'returns the configured value' do
+      described_class.configure(initial_delay: 500)
+      expect(described_class.initial_delay).to eq 500
+    end
+  end
+
+  describe '.delay_strategy' do
+    it 'returns the default value when configure has not been called' do
+      expect(described_class.delay_strategy).to eq EventPeople::Config::DEFAULT_DELAY_STRATEGY
+    end
+
+    it 'returns the configured value' do
+      described_class.configure(delay_strategy: 'fixed')
+      expect(described_class.delay_strategy).to eq 'fixed'
+    end
+  end
+
+  describe '.dlq_name' do
+    it 'defaults to {app_name}_dlq' do
+      expect(described_class.dlq_name).to eq "#{EventPeople::Config::APP_NAME}_dlq"
+    end
+
+    it 'returns the configured value when set via configure' do
+      described_class.configure(dlq_name: 'custom_dlq')
+      expect(described_class.dlq_name).to eq 'custom_dlq'
+    end
+  end
+
+  describe '.configure' do
+    it 'sets multiple options at once' do
+      described_class.configure(
+        max_attempts:   5,
+        initial_delay:  2000,
+        delay_strategy: 'fixed',
+        dlq_name:       'my_dlq'
+      )
+      expect(described_class.max_attempts).to   eq 5
+      expect(described_class.initial_delay).to  eq 2000
+      expect(described_class.delay_strategy).to eq 'fixed'
+      expect(described_class.dlq_name).to       eq 'my_dlq'
+    end
+
+    it 'resets to defaults when called with no arguments' do
+      described_class.configure(max_attempts: 10)
+      described_class.configure
+      expect(described_class.max_attempts).to eq EventPeople::Config::DEFAULT_MAX_ATTEMPTS
+    end
+  end
+
+  describe '.get_retry_config' do
+    it 'returns a hash with max_attempts, initial_delay, delay_strategy, and dlq_name' do
+      config = described_class.get_retry_config
+      expect(config).to include(
+        max_attempts:   EventPeople::Config::DEFAULT_MAX_ATTEMPTS,
+        initial_delay:  EventPeople::Config::DEFAULT_INITIAL_DELAY,
+        delay_strategy: EventPeople::Config::DEFAULT_DELAY_STRATEGY,
+        dlq_name:       "#{EventPeople::Config::APP_NAME}_dlq"
+      )
+    end
+
+    it 'reflects values set via configure' do
+      described_class.configure(max_attempts: 5, initial_delay: 250)
+      config = described_class.get_retry_config
+      expect(config[:max_attempts]).to  eq 5
+      expect(config[:initial_delay]).to eq 250
+    end
   end
 end

--- a/spec/event_people/listener_spec.rb
+++ b/spec/event_people/listener_spec.rb
@@ -2,13 +2,7 @@ describe EventPeople::Listener do
   let(:event_name) { 'resource.origin.action' }
   let(:consumed_event_name) { 'resource.origin.action.all' }
   let(:block) { ->(event, context) { true } }
-  let(:retry_config) do
-    {
-      max_attempts:   EventPeople::Config::MAX_ATTEMPTS,
-      delay_strategy: EventPeople::Config::DELAY_STRATEGY,
-      dlq_name:       EventPeople::Config::DLQ_NAME
-    }
-  end
+  let(:retry_config) { EventPeople::Config.get_retry_config }
 
   describe '.on' do
     before do
@@ -39,6 +33,48 @@ describe EventPeople::Listener do
 
         it 'does not raise an MissingAttributeError' do
           expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when listener_class has custom retry config' do
+        let(:custom_listener) do
+          Class.new(EventPeople::Listeners::Base) do
+            self.max_attempts   = 5
+            self.initial_delay  = 500
+            self.delay_strategy = 'fixed'
+            self.dlq_name       = 'custom_dlq'
+          end
+        end
+
+        subject { described_class.on(event_name, listener_class: custom_listener, &block) }
+
+        it 'merges listener class retry config with Config defaults' do
+          expected_config = {
+            max_attempts:   5,
+            initial_delay:  500,
+            delay_strategy: 'fixed',
+            dlq_name:       'custom_dlq'
+          }
+          expect(EventPeople::Config.broker).to receive(:consume).with(consumed_event_name, retry_config: expected_config)
+
+          subject
+        end
+      end
+
+      context 'when listener_class has partial retry config' do
+        let(:partial_listener) do
+          Class.new(EventPeople::Listeners::Base) do
+            self.max_attempts = 7
+          end
+        end
+
+        subject { described_class.on(event_name, listener_class: partial_listener, &block) }
+
+        it 'merges listener class overrides with Config defaults' do
+          expected_config = retry_config.merge(max_attempts: 7)
+          expect(EventPeople::Config.broker).to receive(:consume).with(consumed_event_name, retry_config: expected_config)
+
+          subject
         end
       end
     end

--- a/spec/event_people/listeners/manager_spec.rb
+++ b/spec/event_people/listeners/manager_spec.rb
@@ -28,7 +28,7 @@ describe EventPeople::Listeners::Manager do
 
     it 'register all listeners on the Manager' do
       configs.each do |config|
-        expect(EventPeople::Listener).to receive(:on).with(config[:routing_key])
+        expect(EventPeople::Listener).to receive(:on).with(config[:routing_key], listener_class: config[:listener_class])
       end
 
       subject


### PR DESCRIPTION
## Spec version

Implements **spec v1.2.0** (released 2026-06-13).

Spec contract: [`spec/contract.yml`](https://github.com/pin-people/event_people/blob/main/spec/contract.yml) in the main `event_people` repository.

## Summary of API changes

### `Config.configure`

A new optional class method replaces the previous env-var-only approach for retry defaults:

```ruby
EventPeople::Config.configure(
  max_attempts:   5,
  initial_delay:  500,
  delay_strategy: 'fixed',
  dlq_name:       'my_app_dlq'
)
```

- Connection attributes (`app_name`, `url`, `vhost`, `topic`) are still read exclusively from environment variables.
- `RABBIT_EVENT_PEOPLE_MAX_RETRIES` and `RABBIT_EVENT_PEOPLE_RETRY_TTL_MS` are no longer consulted (removed from spec v1.2.0).
- Hardcoded defaults (`max_attempts: 3`, `initial_delay: 1000`, `delay_strategy: 'exponential'`) apply when `configure` is not called.
- `Config.get_retry_config` now returns all four keys: `max_attempts`, `initial_delay`, `delay_strategy`, `dlq_name`.

### `BaseListener` class-level retry DSL

Subclasses can now declare per-listener retry settings that override `Config` defaults:

```ruby
class MyListener < EventPeople::Listeners::Base
  self.max_attempts   = 5
  self.initial_delay  = 500
  self.delay_strategy = 'fixed'
  self.dlq_name       = 'my_dlq'
end
```

- All attributes are optional — omitting one falls back to the `Config` default.
- `BaseListener` also gains a public `context` instance accessor (injected by `Queue.callback` before dispatch).

### `Listener.on` signature

The per-call retry keyword arguments (`max_attempts:`, `delay_strategy:`, `dlq_name:`) have been removed. Retry configuration is now resolved from the listener class (or `Config` defaults):

```ruby
# Before (v1.1.x)
EventPeople::Listener.on('user.auth.created', max_attempts: 5) { |event, ctx| ... }

# After (v1.2.0)
EventPeople::Listener.on('user.auth.created', listener_class: MyListener) { |event, ctx| ... }
# or, using Config defaults:
EventPeople::Listener.on('user.auth.created') { |event, ctx| ... }
```

## Test plan

- [ ] `Config.configure` sets and reads back all four retry options
- [ ] `Config.get_retry_config` returns hardcoded defaults when `configure` is never called
- [ ] `BaseListener` subclass with explicit class attrs — retry config reflects those values
- [ ] `BaseListener` subclass with no attrs — falls back to `Config` defaults
- [ ] `Listener.on` without `listener_class:` — uses `Config` defaults
- [ ] `Listener.on` with `listener_class:` — merges listener class attrs over `Config` defaults
- [ ] `context` accessor available inside listener instance methods
- [ ] Existing retry/DLQ behaviour (nack on exhaustion, nack on publish failure) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)