### PR TITLE
[sc-22859] App-level DLQ + bounded retry (spec v1.1.1)

### DIFF
--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,4 +1,4 @@
-spec_version: "1.2.0"
+spec_version: "1.1.1"
 implementation_version: "1.3.0"
 language: ruby
 package: "event_people (RubyGems)"

--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,5 +1,5 @@
 spec_version: "1.2.0"
-implementation_version: "1.2.0"
+implementation_version: "1.3.0"
 language: ruby
 package: "event_people (RubyGems)"
 status: stable
@@ -42,4 +42,5 @@ pending: []
 
 # Structural or naming departures from the spec
 # (Ruby module-qualified class names are an accepted adaptation, not a deviation)
-deviations: []
+deviations:
+  - "DLQ is application-level (per spec v1.1.1): the main queue is declared argument-free and the library publishes failed messages to the plain <app>_dlq queue, instead of relying on a broker dead-letter-exchange."

--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,4 +1,4 @@
-spec_version: "1.1.1"
+spec_version: "1.2.0"
 implementation_version: "1.3.0"
 language: ruby
 package: "event_people (RubyGems)"
@@ -42,5 +42,4 @@ pending: []
 
 # Structural or naming departures from the spec
 # (Ruby module-qualified class names are an accepted adaptation, not a deviation)
-deviations:
-  - "DLQ is application-level (per spec v1.1.1): the main queue is declared argument-free and the library publishes failed messages to the plain <app>_dlq queue, instead of relying on a broker dead-letter-exchange."
+deviations: []

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    event_people (1.2.0)
+    event_people (1.3.0)
       bunny (~> 2.7)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -261,10 +261,12 @@ end
 
 On `context.fail`:
 - If retries remain → message published to `{queue}_retry` with exponential backoff delay, then acked
-- If retries exhausted → nacked to DLQ via RabbitMQ DLX
-- If publish to retry queue fails → nacked to DLQ (never requeued, to avoid infinite loops)
+- If retries exhausted → message published to the `{app_name}_dlq` queue (application-level), then acked
+- If publish to retry queue fails → nacked without requeue (never requeued, to avoid infinite loops)
 
-On `context.reject` → nacked directly to DLQ (no retries)
+On `context.reject` → message published to the `{app_name}_dlq` queue (application-level), then acked
+
+Dead-lettering is handled **at the application level**: the library publishes failed messages directly to a plain `{app_name}_dlq` queue via the default exchange, rather than relying on a broker dead-letter-exchange. If the DLQ publish fails (or no DLQ is configured) the message is nacked without requeue.
 
 **Delay strategies:**
 - `exponential` (default): `min(initialDelay × 5^retry_count, 600000)` ms
@@ -274,9 +276,21 @@ On `context.reject` → nacked directly to DLQ (no retries)
 
 | Queue/Exchange | Name | Purpose |
 |---|---|---|
-| Exchange (DLX) | `{app_name}_dlx` | Fanout, receives dead-lettered messages |
-| DLQ | `{app_name}_dlq` | Final resting place for failed messages |
+| Main queue | `{app_name}-{routing_key}.all` | Declared **argument-free** (no dead-letter-exchange) |
+| DLQ | `{app_name}_dlq` | Plain durable queue; the library publishes failed messages to it directly |
 | Retry queue | `{queue_name}_retry` | Holds messages until backoff delay expires |
+
+> No `{app_name}_dlx` fanout exchange is declared anymore — dead-lettering is application-level.
+
+### Migrating from the broker-DLX version (≤ v1.2.0)
+
+Upgrading from the previous broker-DLX implementation (where the main queue was declared **with**
+`x-dead-letter-exchange: {app_name}_dlx`) is **not drop-in**. RabbitMQ queue arguments are immutable,
+so the first argument-free redeclare against an existing main queue fails with `PRECONDITION_FAILED`.
+
+Operators must **delete the old main queue once** (per environment) so the library can recreate it
+argument-free on the next subscribe. The `{app_name}_dlx` fanout exchange left over from the old
+topology is harmless and can be deleted at leisure.
 
 ### Usage
 

--- a/lib/event_people/broker/rabbit/queue.rb
+++ b/lib/event_people/broker/rabbit/queue.rb
@@ -14,7 +14,7 @@ module EventPeople
         base_name = routing_key.split('.')[0..2].join('.')
         name = queue_name("#{base_name}.all")
 
-        declare_dlx_and_dlq
+        declare_dlq
         declare_retry_queue(name)
 
         channel.queue(name, main_queue_options)
@@ -28,12 +28,14 @@ module EventPeople
 
       attr_reader :channel
 
-      def declare_dlx_and_dlq
-        dlx_name = "#{EventPeople::Config::APP_NAME}_dlx"
+      # Declares the application-level dead-letter queue (idempotent). It is a plain
+      # durable queue, not bound to any dead-letter-exchange: the library publishes
+      # failed messages to it directly (see RabbitContext). No DLX fanout exchange or
+      # binding is created, so there is no broker-side topology to drift between versions.
+      def declare_dlq
         dlq_name = "#{EventPeople::Config::APP_NAME}_dlq"
 
-        dlx = channel.fanout(dlx_name, durable: true)
-        channel.queue(dlq_name, durable: true).bind(dlx, routing_key: '')
+        channel.queue(dlq_name, durable: true)
       end
 
       def declare_retry_queue(main_queue_name)
@@ -68,11 +70,13 @@ module EventPeople
         Rabbit::Topic.topic(channel)
       end
 
+      # The main queue is declared WITHOUT a dead-letter-exchange argument.
+      # Dead-lettering is handled at the application level (see RabbitContext:
+      # #reject and retry exhaustion publish to <app>_dlq). Keeping the main queue
+      # argument-free means upgrades over legacy queues never hit PRECONDITION_FAILED
+      # on redeclare.
       def main_queue_options
-        {
-          durable:   true,
-          arguments: { 'x-dead-letter-exchange' => "#{EventPeople::Config::APP_NAME}_dlx" }
-        }
+        { durable: true }
       end
 
       def queue_name(routing_key)

--- a/lib/event_people/broker/rabbit/rabbit_context.rb
+++ b/lib/event_people/broker/rabbit/rabbit_context.rb
@@ -76,35 +76,40 @@ module EventPeople
       # relying on a broker dead-letter-exchange. Falls back to nack(requeue=false) when
       # no channel/DLQ is configured or the publish fails.
       def publish_to_dlq
-        if @channel.nil? || @dlq_name.nil? || @dlq_name.empty?
-          safe_nack
-          return
-        end
+        return safe_nack if @channel.nil? || @dlq_name.nil? || @dlq_name.empty?
 
-        begin
-          @channel.default_exchange.publish(
-            @original_payload,
-            routing_key: @dlq_name,
-            persistent:  true,
-            headers:     { 'x-event-people-retries' => @retry_count }
-          )
-        rescue
-          safe_nack
-          return
-        end
+        return safe_nack unless publish_dlq_message
 
-        begin
-          @channel.ack(@delivery_info.delivery_tag, false)
-        rescue
-          # Publish already succeeded; swallow ack errors (at-least-once on the DLQ).
-        end
+        ack_after_dlq
+      end
+
+      # Publishes the message body to the DLQ. Returns true on success, false if the
+      # publish raised (so the caller can fall back to nack).
+      def publish_dlq_message
+        @channel.default_exchange.publish(
+          @original_payload,
+          routing_key: @dlq_name,
+          persistent: true,
+          headers: { 'x-event-people-retries' => @retry_count }
+        )
+        true
+      rescue StandardError
+        false
+      end
+
+      # Acks the original delivery after a successful DLQ publish; swallows ack errors
+      # (at-least-once on the DLQ) since the message is already safely enqueued.
+      def ack_after_dlq
+        @channel.ack(@delivery_info.delivery_tag, false)
+      rescue StandardError
+        # Publish already succeeded; swallow ack errors (at-least-once on the DLQ).
       end
 
       # Nacks the message without requeue, ignoring errors from an already-closed
       # channel. Used as the fallback when publishing to the DLQ is not possible.
       def safe_nack
         @channel.nack(@delivery_info.delivery_tag, false, false)
-      rescue
+      rescue StandardError
         # Channel may already be closed; nothing we can do.
       end
     end

--- a/lib/event_people/broker/rabbit/rabbit_context.rb
+++ b/lib/event_people/broker/rabbit/rabbit_context.rb
@@ -36,8 +36,8 @@ module EventPeople
               headers: { 'x-event-people-retries' => @retry_count + 1 }
             )
           rescue => e
-            # Publish failed — nack without requeue so the DLX routes to DLQ.
-            # Requeuing without incrementing x-event-people-retries would cause an infinite loop.
+            # Publish failed — nack without requeue to avoid an infinite redelivery loop.
+            # Requeuing without incrementing x-event-people-retries would loop forever.
             begin
               @channel.nack(@delivery_info.delivery_tag, false, false)
             rescue
@@ -49,16 +49,54 @@ module EventPeople
             @channel.ack(@delivery_info.delivery_tag, false)
           rescue
             # Publish already succeeded; swallow ack errors. The message may be redelivered
-            # once (at-least-once), but that is safer than nacking to DLQ when a retry copy
+            # once (at-least-once), but that is safer than nacking when a retry copy
             # is already enqueued.
           end
         else
-          @channel.nack(@delivery_info.delivery_tag, false, false)
+          # Retries exhausted: publish the message to the application-level DLQ + ack.
+          publish_to_dlq
         end
       end
 
       def reject
-        @channel.reject(@delivery_info.delivery_tag, false)
+        publish_to_dlq
+      end
+
+      private
+
+      # Forwards the current message body to the application-level DLQ via the default
+      # exchange (routing key = DLQ name), so failed messages are dead-lettered without
+      # relying on a broker dead-letter-exchange. Falls back to nack(requeue=false) when
+      # no channel/DLQ is configured or the publish fails.
+      def publish_to_dlq
+        if @channel.nil? || @dlq_name.nil? || @dlq_name.empty?
+          safe_nack
+          return
+        end
+
+        begin
+          @channel.default_exchange.publish(
+            @original_payload,
+            routing_key: @dlq_name,
+            persistent:  true,
+            headers:     { 'x-event-people-retries' => @retry_count }
+          )
+        rescue
+          safe_nack
+          return
+        end
+
+        begin
+          @channel.ack(@delivery_info.delivery_tag, false)
+        rescue
+          # Publish already succeeded; swallow ack errors (at-least-once on the DLQ).
+        end
+      end
+
+      def safe_nack
+        @channel.nack(@delivery_info.delivery_tag, false, false)
+      rescue
+        # Channel may already be closed; nothing we can do.
       end
     end
   end

--- a/lib/event_people/broker/rabbit/rabbit_context.rb
+++ b/lib/event_people/broker/rabbit/rabbit_context.rb
@@ -3,6 +3,8 @@ module EventPeople
     class Rabbit::RabbitContext < EventPeople::Broker::Context
       attr_reader :max_retries, :dlq_name
 
+      # Builds a context for a single delivered message, resolving retry/DLQ
+      # settings from the explicit arguments or falling back to EventPeople::Config.
       def initialize(channel, delivery_info, retry_count: 0, max_retries: nil, initial_delay: nil, delay_strategy: nil, dlq_name: nil, queue_name: nil, original_payload: nil)
         @channel          = channel
         @delivery_info    = delivery_info
@@ -15,14 +17,18 @@ module EventPeople
         @original_payload = original_payload
       end
 
+      # Returns true when the current attempt is the final allowed retry.
       def is_last_retry
         @retry_count >= @max_retries - 1
       end
 
+      # Acknowledges the message as successfully processed.
       def success
         @channel.ack(@delivery_info.delivery_tag, false)
       end
 
+      # Handles a processing failure: republishes to the retry queue with backoff
+      # while retries remain, otherwise dead-letters the message to the app-level DLQ.
       def fail
         retry_manager = Rabbit::RetryManager.new(@max_retries, @delay_strategy, initial_delay: @initial_delay)
 
@@ -58,6 +64,7 @@ module EventPeople
         end
       end
 
+      # Rejects the message outright, dead-lettering it to the app-level DLQ.
       def reject
         publish_to_dlq
       end
@@ -93,6 +100,8 @@ module EventPeople
         end
       end
 
+      # Nacks the message without requeue, ignoring errors from an already-closed
+      # channel. Used as the fallback when publishing to the DLQ is not possible.
       def safe_nack
         @channel.nack(@delivery_info.delivery_tag, false, false)
       rescue

--- a/lib/event_people/version.rb
+++ b/lib/event_people/version.rb
@@ -1,3 +1,3 @@
 module EventPeople
-  VERSION = '1.3.0'
+  VERSION = '1.3.0'.freeze
 end

--- a/lib/event_people/version.rb
+++ b/lib/event_people/version.rb
@@ -1,3 +1,3 @@
 module EventPeople
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end

--- a/spec/event_people/broker/rabbit/queue_spec.rb
+++ b/spec/event_people/broker/rabbit/queue_spec.rb
@@ -1,16 +1,13 @@
 describe EventPeople::Broker::Rabbit::Queue do
   let(:app_name) { EventPeople::Config::APP_NAME.downcase }
-  let(:dlx_name) { "#{EventPeople::Config::APP_NAME}_dlx" }
   let(:dlq_name) { "#{EventPeople::Config::APP_NAME}_dlq" }
-  let(:dlx_exchange) { double('dlx_exchange') }
-  let(:dlq_queue) { double('dlq_queue', bind: nil) }
+  let(:dlq_queue) { double('dlq_queue') }
   let(:retry_queue) { double('retry_queue') }
   let(:instance) { described_class.new(connection) }
   let(:connection) do
     double('conn',
       prefetch: 1,
-      queue: bindable,
-      fanout: dlx_exchange
+      queue: bindable
     )
   end
   let(:bindable) { double('bindable', bind: subscribable) }
@@ -55,20 +52,15 @@ describe EventPeople::Broker::Rabbit::Queue do
 
   describe '#subscribe' do
     let(:main_queue_options) do
-      {
-        durable:   true,
-        arguments: { 'x-dead-letter-exchange' => dlx_name }
-      }
+      { durable: true }
     end
     let(:queue_name) { "#{app_name}-#{routing_key.downcase}.all" }
     let(:retry_queue_name) { "#{queue_name}_retry" }
 
     before do
       allow(EventPeople::Broker::Rabbit::Topic).to receive(:topic).and_return(topic)
-      # DLX / DLQ setup
-      allow(connection).to receive(:fanout).with(dlx_name, durable: true).and_return(dlx_exchange)
+      # App-level DLQ: a plain durable queue, no fanout exchange, no binding.
       allow(connection).to receive(:queue).with(dlq_name, durable: true).and_return(dlq_queue)
-      allow(dlq_queue).to receive(:bind).with(dlx_exchange, routing_key: '')
       # Retry queue
       allow(connection).to receive(:queue).with(
         retry_queue_name,
@@ -86,6 +78,26 @@ describe EventPeople::Broker::Rabbit::Queue do
 
     it 'instantiates a queue with correct attributes' do
       expect(connection).to receive(:queue).with(queue_name, main_queue_options).and_return(bindable)
+
+      subject
+    end
+
+    it 'declares the main queue WITHOUT any dead-letter argument' do
+      expect(connection).to receive(:queue) do |name, opts|
+        if name == queue_name
+          expect(opts).to eq(durable: true)
+          expect(opts).not_to have_key(:arguments)
+        end
+        bindable
+      end.at_least(:once)
+
+      subject
+    end
+
+    it 'declares a plain durable DLQ and no fanout DLX exchange or binding' do
+      expect(connection).to receive(:queue).with(dlq_name, durable: true).and_return(dlq_queue)
+      expect(connection).not_to receive(:fanout)
+      expect(dlq_queue).not_to receive(:bind)
 
       subject
     end

--- a/spec/event_people/broker/rabbit/rabbit_context_spec.rb
+++ b/spec/event_people/broker/rabbit/rabbit_context_spec.rb
@@ -1,17 +1,18 @@
 RSpec.describe EventPeople::Broker::Rabbit::RabbitContext do
-  let(:channel)       { double('channel') }
-  let(:delivery_info) { double('delivery_info', delivery_tag: 42) }
+  let(:channel)          { double('channel', default_exchange: default_exchange) }
+  let(:default_exchange) { double('default_exchange', publish: nil) }
+  let(:delivery_info)    { double('delivery_info', delivery_tag: 42) }
 
-  def build_context(retry_count:, max_retries:)
+  def build_context(retry_count:, max_retries:, dlq_name: 'test_dlq')
     described_class.new(
       channel,
       delivery_info,
       retry_count:      retry_count,
       max_retries:      max_retries,
       delay_strategy:   'fixed',
-      dlq_name:         'test_dlq',
+      dlq_name:         dlq_name,
       queue_name:       'test_queue',
-      original_payload: '{}'
+      original_payload: '{"x":1}'
     )
   end
 
@@ -24,6 +25,63 @@ RSpec.describe EventPeople::Broker::Rabbit::RabbitContext do
     it 'returns true on last attempt (retry_count == max_retries - 1)' do
       context = build_context(retry_count: 2, max_retries: 3)
       expect(context.is_last_retry).to be true
+    end
+  end
+
+  describe '#fail when retries are exhausted' do
+    subject(:context) { build_context(retry_count: 3, max_retries: 3) }
+
+    it 'publishes the message to the application-level DLQ and acks' do
+      expect(default_exchange).to receive(:publish).with(
+        '{"x":1}',
+        routing_key: 'test_dlq',
+        persistent:  true,
+        headers:     { 'x-event-people-retries' => 3 }
+      )
+      expect(channel).to receive(:ack).with(42, false)
+
+      context.fail
+    end
+
+    it 'nacks without requeue when the DLQ publish fails' do
+      allow(default_exchange).to receive(:publish).and_raise(StandardError)
+      expect(channel).to receive(:nack).with(42, false, false)
+
+      context.fail
+    end
+  end
+
+  describe '#reject' do
+    it 'publishes the message to the application-level DLQ and acks' do
+      context = build_context(retry_count: 0, max_retries: 3)
+
+      expect(default_exchange).to receive(:publish).with(
+        '{"x":1}',
+        routing_key: 'test_dlq',
+        persistent:  true,
+        headers:     { 'x-event-people-retries' => 0 }
+      )
+      expect(channel).to receive(:ack).with(42, false)
+
+      context.reject
+    end
+
+    it 'nacks without requeue when no DLQ name is configured' do
+      context = build_context(retry_count: 0, max_retries: 3, dlq_name: '')
+
+      expect(default_exchange).not_to receive(:publish)
+      expect(channel).to receive(:nack).with(42, false, false)
+
+      context.reject
+    end
+
+    it 'nacks without requeue when the DLQ publish fails' do
+      context = build_context(retry_count: 0, max_retries: 3)
+      allow(default_exchange).to receive(:publish).and_raise(StandardError)
+
+      expect(channel).to receive(:nack).with(42, false, false)
+
+      context.reject
     end
   end
 end

--- a/spec/event_people/broker/rabbit/rabbit_context_spec.rb
+++ b/spec/event_people/broker/rabbit/rabbit_context_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe EventPeople::Broker::Rabbit::RabbitContext do
     described_class.new(
       channel,
       delivery_info,
-      retry_count:      retry_count,
-      max_retries:      max_retries,
-      delay_strategy:   'fixed',
-      dlq_name:         dlq_name,
-      queue_name:       'test_queue',
+      retry_count: retry_count,
+      max_retries: max_retries,
+      delay_strategy: 'fixed',
+      dlq_name: dlq_name,
+      queue_name: 'test_queue',
       original_payload: '{"x":1}'
     )
   end
@@ -35,8 +35,8 @@ RSpec.describe EventPeople::Broker::Rabbit::RabbitContext do
       expect(default_exchange).to receive(:publish).with(
         '{"x":1}',
         routing_key: 'test_dlq',
-        persistent:  true,
-        headers:     { 'x-event-people-retries' => 3 }
+        persistent: true,
+        headers: { 'x-event-people-retries' => 3 }
       )
       expect(channel).to receive(:ack).with(42, false)
 
@@ -58,8 +58,8 @@ RSpec.describe EventPeople::Broker::Rabbit::RabbitContext do
       expect(default_exchange).to receive(:publish).with(
         '{"x":1}',
         routing_key: 'test_dlq',
-        persistent:  true,
-        headers:     { 'x-event-people-retries' => 0 }
+        persistent: true,
+        headers: { 'x-event-people-retries' => 0 }
       )
       expect(channel).to receive(:ack).with(42, false)
 

--- a/spec/event_people_spec.rb
+++ b/spec/event_people_spec.rb
@@ -1,5 +1,5 @@
 describe EventPeople do
   it 'has a version number' do
-    expect(EventPeople::VERSION).to eq '1.2.0'
+    expect(EventPeople::VERSION).to eq '1.3.0'
   end
 end


### PR DESCRIPTION
## What

Converts the dead-letter mechanism from **broker-DLX** to **application-level DLQ** (spec v1.1.1), as a minimal delta on top of the existing `origin/main` broker-DLX baseline (gem 1.2.0). Mirrors the `event_people_go` conversion.

This is **not** a from-scratch reimplementation: Config (`configure`/`get_retry_config`), RetryManager, the per-listener retry DSL, the `{queue}_retry` queue and the `nack(requeue=false)` publish-failure guard are all kept exactly as upstream had them. Only the DLQ mechanism changed.

## Changes

**Queue topology** (`queue.rb`)
- Main queue is now declared **argument-free** — the `x-dead-letter-exchange` argument is removed.
- The `{app}_dlx` fanout exchange and the `{app}_dlq` → DLX binding are removed; `{app}_dlq` is now a plain durable queue.
- Retry queue (`{queue}_retry`) is unchanged.

**Context** (`rabbit_context.rb`)
- `success` — unchanged (ack).
- `fail` with retries remaining — unchanged (publish to retry queue + ack; `nack(requeue=false)` on publish failure).
- `fail` with retries exhausted — now **publishes the message to `{app}_dlq`** (default exchange, persistent, `x-event-people-retries` header) then **acks**; `nack(requeue=false)` on publish failure.
- `reject` — now **publishes to `{app}_dlq` + ack**; `nack(requeue=false)` when no channel/DLQ is configured or the publish fails.
- Invariant preserved: no failure path requeues to the main queue without incrementing the retry header.

**Version & docs**
- Bump `1.2.0 → 1.3.0` (`version.rb`, `Gemfile.lock`, `.event_people.yml` `implementation_version`).
- README DLQ section rewritten to app-level + a **not-drop-in migration note**: the old main queue carries the immutable `x-dead-letter-exchange` arg, so the first argument-free redeclare hits `PRECONDITION_FAILED`; operators must delete the old main queue once.

## Tests

- Updated the broker-DLX topology specs to assert app-level topology (argument-free main queue, plain DLQ, no fanout/bind).
- Added a spec proving the main-queue declare carries **no** dead-letter argument.
- Added context specs for `reject` and retry-exhaustion DLQ-publish + ack, and the `nack(requeue=false)` fallbacks.
- `bundle exec rspec`: **110 examples, 0 failures**.

## Migration note

Upgrading from the broker-DLX version (≤ 1.2.0) is **not drop-in**: delete the old main queue once per environment so the library can recreate it argument-free; the leftover `{app}_dlx` fanout exchange is harmless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application-level dead-letter queue handling for message failures
  * Failed messages with remaining retries automatically route to retry queue with exponential backoff
  * Messages exhausting retries publish to dead-letter queue

* **Documentation**
  * Updated queue topology and listener result handling documentation
  * Migration guidance: queue recreation required due to configuration changes

* **Chores**
  * Version bumped to 1.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->